### PR TITLE
add remove backup file when upload failed

### DIFF
--- a/mysqlbackup.py
+++ b/mysqlbackup.py
@@ -460,8 +460,6 @@ class MysqlBackup(object):
         self.backup_binlog()
         self.calc_checksum()
         self.upload_backup()
-        self.shell_run('remove backup {backup_data_dir} {backup_binlog_dir}',
-                       'rm -rf {backup_data_dir} {backup_binlog_dir}')
 
         self.info("backup OK")
 
@@ -562,17 +560,21 @@ class MysqlBackup(object):
         # boto adds Content-MD5 automatically
         extra_args = {'Metadata': self.bkp_conf['backup_tgz_des3_meta']}
 
-        boto_put(bc,
-                 self.render('{backup_tgz_des3}'),
-                 self.render('{s3_bucket}'),
-                 self.render('{s3_key}'),
-                 extra_args
-                 )
+        try:
+            boto_put(bc,
+                     self.render('{backup_tgz_des3}'),
+                     self.render('{s3_bucket}'),
+                     self.render('{s3_key}'),
+                     extra_args
+                     )
+        finally:
+            self.shell_run('remove backup {backup_tgz_des3}',
+                           'rm -rf {backup_tgz_des3}')
+            self.shell_run('remove backup {backup_data_dir} {backup_binlog_dir}',
+                           'rm -rf {backup_data_dir} {backup_binlog_dir}')
 
         self.info_r('backup to s3://{s3_bucket}/{s3_key} OK')
 
-        self.shell_run('remove backup {backup_tgz_des3}',
-                       'rm -rf {backup_tgz_des3}')
 
     def restore(self):
 

--- a/mysqlbackup.py
+++ b/mysqlbackup.py
@@ -457,7 +457,8 @@ class MysqlBackup(object):
 
         self.info("backup ...")
 
-        self.remove_backup_file()
+        self.remove_backup(
+                'remove old backup {backup_tgz_des3} {backup_data_dir} {backup_binlog_dir}')
 
         try:
             self.backup_data()
@@ -466,7 +467,9 @@ class MysqlBackup(object):
             self.upload_backup()
             self.info_r('backup to s3://{s3_bucket}/{s3_key} OK')
         finally:
-            self.remove_backup_file()
+            self.remove_backup(
+                    'remove backup {backup_tgz_des3} {backup_data_dir} {backup_binlog_dir}')
+
 
     def backup_data(self):
 
@@ -579,7 +582,6 @@ class MysqlBackup(object):
 
             try:
                 resp = boto_head(bc,
-                        self.reader('{backup_tgz_des3}'),
                         self.render('{s3_bucket}'),
                         self.render('{s3_key}')
                         )
@@ -591,13 +593,14 @@ class MysqlBackup(object):
                 self.info('backup file: {backup_tgz_des3} already in s2 cloud')
             else:
                 self.error(repr(e) + 'get backup file: {backup_tgz_des3} error')
-                raise
+                raise S3UploadFailedError(repr(e) + 'while upload backup file failed')
 
 
-    def remove_backup_file(self):
+    def remove_backup(self, cmd_info):
 
-            self.shell_run('remove backup {backup_tgz_des3} {backup_data_dir} {backup_binlog_dir}',
-                           'rm -rf {backup_tgz_des3} {backup_data_dir} {backup_binlog_dir}')
+        self.shell_run(cmd_info,
+                'rm -rf {backup_tgz_des3} {backup_data_dir} {backup_binlog_dir}')
+
 
     def restore(self):
 

--- a/mysqlops.py
+++ b/mysqlops.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
 
-    rootlogger = logutil.make_logger(base_dir='/tmp',
+    rootlogger = logutil.make_logger(base_dir='/var/log',
                                      log_fn=logutil.get_root_log_fn(),
                                      level=logging.DEBUG)
     logutil.add_std_handler(rootlogger, stream=sys.stdout)


### PR DESCRIPTION
### 解决什么问题
最近发现mysql备份过程中经常会遇到磁盘空间不足的问题
- 经排查发现在备份worker设置个数为1的情况依然后多个端口的备份文件在backup目录下, 不符合代码逻辑的预期
- 排查日志发现如下异常：
```
[2018-08-09 21:37:38,586,16062-140305259050752,mysqlops.py,102,ERROR] S3UploadFailedError('Failed to upload /data1/backup/mysql-3505.tgz.des3 to mysql-backup/2018_08_06/3505/mysql-3505.tgz.des3: An error occurred (InvalidPart) when calling the CompleteMultipartUpload operation: not found part: 1',)
```
- 查看代码逻辑, 发现当upload_backup抛出异常，程序不会清理备份文件，而是进入下一个端口的备份流程，按照此逻辑，如果多个端口在upload_backup过程出现异常，很可能会出现磁盘空间不足的告警

### 如何处理

-  排查uploadFailedError 异常出现原因（义谱ing）
- 在upload_backup 中增加finally 语句，此过程出现异常，清理备份文件（此PR）